### PR TITLE
Twirling bar animation 8080 demo

### DIFF
--- a/plugins/compiler/as-8080/src/main/examples/twirl.asm
+++ b/plugins/compiler/as-8080/src/main/examples/twirl.asm
@@ -1,0 +1,38 @@
+; Twirling bar animation by Paolo Amoroso <info@paoloamoroso.com>
+;
+; Runs on an Altair 8800 with an ADM-3A terminal. To interrupt
+; the program click "Stop emulation".
+
+
+FRAMES    equ  8              ; Number of animation frames
+
+CLS       equ  1ah            ; ADM-3A escape sequence
+HOME      equ  1eh            ; ADM-3A escape sequence
+
+
+          mvi  a, CLS         ; Clear screen
+          call putchar
+
+loop:     lxi  h, ANIM
+          mvi  b, FRAMES
+
+loop1:    mvi  a, HOME        ; Go to home
+          call putchar
+
+          mov  a, m           ; Print current frame
+          push h
+          call putchar
+
+          inx  h
+          dcr  b
+          jnz  loop1
+
+          jmp  loop
+
+          hlt
+
+
+ANIM:     db   '|/-\|/-\'    ; 8 frames
+
+
+include 'include\putchar.inc'


### PR DESCRIPTION
This program is a modified version of my [Twirl](https://journal.paoloamoroso.com/twirl-an-intel-8080-assembly-program) 8080 demo.

Unlike the original version, which is intended to be ported to CP/M, the one I'm submitting here is designed to run only on emuStudio. This makes the code simpler as the ADM-3A escape codes the program uses are single bytes, only the `putchar` I/O subroutine is required, and the calls don't need to preserve any registers.

I donate this code to the emuStudio project under the GPL 3.0 license.