### PR TITLE
Remove extra instruction and check for program termination

### DIFF
--- a/plugins/compiler/as-8080/src/main/examples/twirl.asm
+++ b/plugins/compiler/as-8080/src/main/examples/twirl.asm
@@ -1,13 +1,15 @@
 ; Twirling bar animation by Paolo Amoroso <info@paoloamoroso.com>
 ;
-; Runs on an Altair 8800 with an ADM-3A terminal. To interrupt
-; the program click "Stop emulation".
+; Runs on an Altair 8800 with an ADM-3A terminal. Press any key
+; to interrupt the program.
 
 
 FRAMES    equ  8              ; Number of animation frames
 
 CLS       equ  1ah            ; ADM-3A escape sequence
 HOME      equ  1eh            ; ADM-3A escape sequence
+STATUS	equ  10h            ; Input status port
+READY     equ  1              ; Character ready status mask
 
 
           mvi  a, CLS         ; Clear screen
@@ -20,19 +22,25 @@ loop1:    mvi  a, HOME        ; Go to home
           call putchar
 
           mov  a, m           ; Print current frame
-          push h
           call putchar
 
           inx  h
           dcr  b
+
+          push psw
+          in   STATUS         ; Key pressed?
+          ani  READY
+          jnz  exit           ; Yes
+          pop  psw
+
           jnz  loop1
 
           jmp  loop
-
-          hlt
+					
+exit:     hlt
 
 
 ANIM:     db   '|/-\|/-\'    ; 8 frames
 
 
-include 'include\putchar.inc'
+include	'include\putchar.inc'


### PR DESCRIPTION
I removed the spurious leftover `push h` instruction and added code to terminate the program if a key is pressed.